### PR TITLE
fix: normalize empty dbname to default in dataBase constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.2.2] - 2026-04-10
+
+### Fixed
+
+- Risolto un bug per cui passare una stringa vuota `""` come `$dbname` in `dataBase::__construct()` e `Utils::__construct()` causava la ricerca di variabili d'ambiente inesistenti (`DB_HOST_`, `DB_USER_`, ecc.), risultando in una connessione fallita. Una stringa vuota viene ora normalizzata a `"default"`. Introdotto in v5.1.0.
+
 ## [5.2.1] - 2026-04-07
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ottimis/phplibs",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "keywords": [
     "release",
     "official",

--- a/src/dataBase.php
+++ b/src/dataBase.php
@@ -22,6 +22,9 @@ class dataBase implements DatabaseInterface
 
     public function __construct($dbname = "default")
     {
+        if ($dbname === "") {
+            $dbname = "default";
+        }
         $this->host = ($dbname === "default" ? getenv('DB_HOST') : getenv('DB_HOST_' . $dbname));
         $this->user = ($dbname === "default" ? getenv('DB_USER') : getenv('DB_USER_' . $dbname));
         $this->password = ($dbname === "default" ? getenv('DB_PASSWORD') : getenv('DB_PASSWORD_' . $dbname));


### PR DESCRIPTION
Passing "" as $dbname caused the constructor to look for DB_HOST_, DB_USER_, etc. instead of DB_HOST, DB_USER — resulting in empty credentials and a failed connection. Introduced in v5.1.0 when the sentinel was changed from "" to "default".