### PR TITLE
feat: add SQL_MODE env variable for gradual strict mode migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.2.3] - 2026-04-21
+
+### Added
+
+- Aggiunto supporto per la variabile d'ambiente `SQL_MODE` che permette di impostare flag SQL specifici per sessione. Utile per la migrazione graduale dalla modalità legacy (`SQL_MODE_LEGACY=true`) alla modalità strict di MariaDB/MySQL.
+
 ## [5.2.2] - 2026-04-10
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ottimis/phplibs",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "keywords": [
     "release",
     "official",

--- a/src/dataBase.php
+++ b/src/dataBase.php
@@ -37,6 +37,8 @@ class dataBase implements DatabaseInterface
         $this->conn = mysqli_connect($this->host, $this->user, $this->password, $this->database, $this->port) or die("Could not connect " . mysqli_connect_error());
         if (getenv("SQL_MODE_LEGACY") === "true") {
             $this->query("SET sql_mode = '';");
+        } elseif (getenv("SQL_MODE") !== false) {
+            $this->query("SET sql_mode = '" . getenv("SQL_MODE") . "';");
         }
     }
 


### PR DESCRIPTION
Allow setting specific SQL mode flags per session via the SQL_MODE environment variable, enabling incremental migration from legacy (empty sql_mode) to MariaDB/MySQL default strict mode.