### PR TITLE
feat(OGStorage): CDN URL support and config override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ottimis/phplibs",
-  "version": "5.2.4",
+  "version": "5.3.0",
   "keywords": [
     "release",
     "official",

--- a/src/OGStorage.php
+++ b/src/OGStorage.php
@@ -11,15 +11,33 @@ class OGStorage
 {
     private S3Client $client;
     private string $bucket;
+    private ?string $cdnUrl;
     protected Logger $Logger;
 
-    public function __construct(?string $bucket = null)
+    /**
+     * @param string|null $bucket Bucket name. Defaults to S3_BUCKET env var.
+     * @param string|null $cdnUrl CDN base URL (e.g. https://docs.example.com). Defaults to S3_CDN_URL env var.
+     *                            Used by getCdnUrl() and returned alongside object URL on uploads.
+     * @param array $configOverride Full S3Client config to override env-based defaults. When provided,
+     *                              env vars (S3_REGION, S3_ENDPOINT, S3_ACCESS_KEY, ...) are ignored
+     *                              and only this array (merged with version=latest) is used. Useful for
+     *                              instantiating multiple clients (e.g. cross-cloud sync) in the same process.
+     */
+    public function __construct(?string $bucket = null, ?string $cdnUrl = null, array $configOverride = [])
     {
         $this->Logger = Logger::getInstance();
         $this->bucket = $bucket ?? getenv('S3_BUCKET') ?: '';
 
         if (empty($this->bucket)) {
             throw new RuntimeException("S3 bucket is required. Set S3_BUCKET env or pass it to the constructor.");
+        }
+
+        $this->cdnUrl = $cdnUrl ?? (getenv('S3_CDN_URL') ?: null);
+
+        if (!empty($configOverride)) {
+            $config = array_merge(['version' => 'latest'], $configOverride);
+            $this->client = new S3Client($config);
+            return;
         }
 
         $config = [
@@ -99,6 +117,7 @@ class OGStorage
                 data: [
                     'key' => $key,
                     'url' => $result['ObjectURL'] ?? $this->getUrl($key),
+                    'cdn_url' => $this->getCdnUrl($key),
                 ]
             );
         } catch (\Throwable $e) {
@@ -143,6 +162,7 @@ class OGStorage
                 data: [
                     'key' => $key,
                     'url' => $result['ObjectURL'] ?? $this->getUrl($key),
+                    'cdn_url' => $this->getCdnUrl($key),
                 ]
             );
         } catch (\Throwable $e) {
@@ -277,6 +297,19 @@ class OGStorage
     }
 
     /**
+     * Generate the CDN URL for an object.
+     * Falls back to the S3 object URL when no CDN base is configured
+     * (via S3_CDN_URL env var or constructor argument).
+     */
+    public function getCdnUrl(string $key): string
+    {
+        if (empty($this->cdnUrl)) {
+            return $this->getUrl($key);
+        }
+        return rtrim($this->cdnUrl, '/') . '/' . ltrim($key, '/');
+    }
+
+    /**
      * Generate a pre-signed (temporary) URL for an object.
      *
      * @param string $key Object key
@@ -365,6 +398,7 @@ class OGStorage
                 data: [
                     'key' => $destinationKey,
                     'url' => $this->getUrl($destinationKey),
+                    'cdn_url' => $this->getCdnUrl($destinationKey),
                 ]
             );
         } catch (\Throwable $e) {


### PR DESCRIPTION
## Summary
- Add optional `cdnUrl` constructor param + `S3_CDN_URL` env var, with `getCdnUrl(key)` method that falls back to the S3 object URL when no CDN is configured.
- Include `cdn_url` in the `data` payload of `upload()`, `put()`, `putBase64()`, and `copy()` so callers can store the right URL directly.
- Add `configOverride` constructor param to bypass env-based defaults, enabling multiple `OGStorage` instances pointing to different buckets/clouds in the same process (needed e.g. for DO Spaces → AWS S3 migration scripts).
- Bump version to `5.3.0`.

## Why
We are migrating Lindhaus assets from DigitalOcean Spaces to AWS S3 served by CloudFront at `docs.ottimis.com`. We need:
1. A clean way to compose CDN URLs (per-project, since the CDN host varies).
2. Two `OGStorage` clients live in the same process during the migration (one pointing to DO Spaces, one to AWS).

## Test plan
- [ ] Existing usage (no `cdnUrl`, no `configOverride`) keeps working — `cdn_url` falls back to S3 object URL.
- [ ] `S3_CDN_URL` env yields `https://docs.example.com/<key>`.
- [ ] Constructor `cdnUrl` arg overrides env.
- [ ] `configOverride` bypasses all `S3_*` env vars and uses the provided client config (region, endpoint, credentials).
- [ ] `getCdnUrl` correctly handles trailing/leading slashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)